### PR TITLE
record: defalut-utoipa_swagger_ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +601,17 @@ checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -665,6 +694,17 @@ name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flate2"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1157,6 +1197,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1261,6 +1303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,12 +1371,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1501,6 +1563,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1843,6 +1911,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.106",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +2011,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2171,6 +2282,9 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -2228,6 +2342,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -2862,6 +2982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3045,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,6 +3121,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -3038,6 +3229,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3459,4 +3659,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ clap = "4.5"
 anyhow = "1.0.100"
 tracing = "0.1.41"
 
+utoipa-axum = { version = "0.2", features = ["debug"] }
+utoipa = { version = "5.1.1", features = ["axum_extras", "debug", "default"] }
+utoipa-swagger-ui = {version = "9.0.2", features = ["axum"]}
+
 [dependencies]
 server = { path="server"}
 clap = {workspace = true, features = ["derive"]}
@@ -58,3 +62,4 @@ lto = true
 [features]
 default = ["webp"]
 webp = []
+openapi = ["server/openapi"]

--- a/libs/auth/src/access.rs
+++ b/libs/auth/src/access.rs
@@ -1,33 +1,35 @@
 // 检验 token 的中间件
-use crate::claim::{Claim};
-use axum::{extract::Request,  middleware::Next, response::Response};
+use crate::claim::Claim;
 use axum::http::{HeaderMap, header::AUTHORIZATION};
-use jsonwebtoken::{encode, decode, EncodingKey, Header, DecodingKey, Validation};
+use axum::{extract::Request, middleware::Next, response::Response};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 
 /** Token*/
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct Token(pub String);
 
 /** 生成一个token*/
-pub fn generate_token(claim: Claim, secret: &str) -> String{
+pub fn generate_token(claim: Claim, secret: &str) -> String {
     // 生成 token
     let token = encode(
         &Header::default(),
         &claim,
         &EncodingKey::from_secret(secret.as_ref()),
-    ).expect("JWT encode failed");
+    )
+    .expect("JWT encode failed");
 
     token
 }
 
 /** 检验token的有效性 */
-pub fn check_token(token: String, secret: &str) -> bool{
+pub fn check_token(token: String, secret: &str) -> bool {
     // 检查 解密
     decode::<Claim>(
         &token,
         &DecodingKey::from_secret(secret.as_ref()),
         &Validation::default(),
-    ).is_ok()
+    )
+    .is_ok()
 }
 
 /** 身份校验 权限中间件*/
@@ -48,6 +50,11 @@ pub async fn access_middleware(req: Request, next: Next) -> Response {
 // 身份校验
 pub(crate) fn get_token(headers: &HeaderMap) -> Option<String> {
     // let value = headers.get(AUTHORIZATION)?.to_str().ok()?;
-    headers.get(AUTHORIZATION)?.to_str().ok()?.strip_prefix("Bearer ").map(|s| s.to_string())
+    headers
+        .get(AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+        .map(|s| s.to_string())
     // value.strip_prefix("Bearer ")?
 }

--- a/libs/auth/src/claim.rs
+++ b/libs/auth/src/claim.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claim {
     pub id: String, // 用户id
@@ -17,11 +16,11 @@ impl Display for Claim {
 
 #[test]
 fn test_claim() {
-    use chrono::{Utc, TimeZone, Duration};
     use crate::claim::Claim;
+    use chrono::{Duration, TimeZone, Utc};
     let ita_now = Utc::now().timestamp();
     let offset_ts = (Utc::now() + Duration::hours(1)).timestamp();
-    let claim  = Claim{
+    let claim = Claim {
         id: "1".to_string(),
         exp: offset_ts as u64,
         ita: ita_now as u64,

--- a/libs/auth/src/lib.rs
+++ b/libs/auth/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod claim;
 pub mod access;
+pub mod claim;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,10 @@ tokio = { workspace = true, features = ["signal"] }
 axum = { workspace = true, features = ["multipart", "tracing"] }
 tracing = {workspace = true}
 
+utoipa = { workspace= true, optional = true }
+utoipa-axum = {workspace = true ,optional = true}
+utoipa-swagger-ui = { workspace= true, optional = true }
+
 log = "0.4.28"
 # 提供常用的中间件
 tower-http = { version = "0.6.6", features = ["trace", "cors"] }
@@ -30,3 +34,6 @@ sea-orm = { version = "1.1", features = [
 ]}
 
 sea-orm-migration = "1.0"
+
+[features]
+openapi= ["dep:utoipa","dep:utoipa-swagger-ui", "dep:utoipa-axum"]

--- a/server/src/route/hello.rs
+++ b/server/src/route/hello.rs
@@ -4,11 +4,30 @@ use axum::routing::get;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
+// utoipa宏会自动生成路径模块，不需要手动定义
+
+#[cfg(feature = "openapi")]
+use crate::route::swagger_ui::ApiDoc;
+#[cfg(feature = "openapi")]
+use utoipa::OpenApi;
+#[cfg(feature = "openapi")]
+use utoipa_axum::router::OpenApiRouter;
+#[cfg(feature = "openapi")]
+use utoipa_axum::routes;
+#[cfg(feature = "openapi")]
+use utoipa_swagger_ui::SwaggerUi;
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Deserialize, Serialize)]
 pub struct Hello {
     pub msg: String,
 }
 
+#[cfg_attr(feature="openapi",utoipa::path(
+    get,
+    path = "/hello",
+    responses((status= 200, description = "你好路由!", body= Hello)),
+))]
 pub async fn hello_handler() -> Result<Json<Hello>, StatusCode> {
     Ok(Json(Hello {
         msg: "你好！".to_string(),

--- a/server/src/route/mod.rs
+++ b/server/src/route/mod.rs
@@ -1,14 +1,33 @@
 pub mod hello;
 pub mod user;
+pub mod swagger_ui;
 
 use crate::AppState;
 use axum::Router;
 pub use hello::*;
 
+
 // 获取所有路由
 pub fn get_routes() -> Router<AppState> {
-    let routes = Router::new()
+    let mut routes = Router::new()
         .merge(user::get_routes())
         .merge(hello::get_routes());
+    #[cfg(feature = "openapi")]
+    {
+        routes = routes.merge(get_routes_docs());
+    }
     routes
+}
+
+#[cfg(feature = "openapi")]
+pub fn get_routes_docs() -> Router<AppState> {
+    use swagger_ui::ApiDoc;
+    use utoipa::OpenApi;
+    use utoipa_swagger_ui::SwaggerUi;
+
+    let openapi = ApiDoc::openapi();
+    SwaggerUi::new("/docs")
+        .url("/api-docs/openapi.json", openapi)
+        .into()
+
 }

--- a/server/src/route/swagger_ui.rs
+++ b/server/src/route/swagger_ui.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "openapi")]
+use utoipa::OpenApi;
+
+// 导入utoipa自动生成的路径模块
+#[cfg(feature = "openapi")]
+use crate::route::hello_handler;
+
+#[cfg(feature = "openapi")]
+use crate::route::__path_hello_handler;
+
+
+#[cfg(feature = "openapi")]
+use crate::route::user::UserApi;
+// 使用derive宏来创建简单的OpenAPI文档
+#[cfg(feature = "openapi")]
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "后端服务API",
+        description = "这是服务器的API文档",
+        version = "0.0.1"
+    ),
+    paths(
+        hello_handler,
+    ),
+    nest(
+        (path = "/users", api = UserApi)
+    )
+)]
+#[cfg_attr(not(feature = "openapi"), allow(unused))]
+pub struct ApiDoc;

--- a/server/src/route/user.rs
+++ b/server/src/route/user.rs
@@ -1,14 +1,24 @@
 use crate::AppState;
 use crate::error::AppError;
 use anyhow::Error;
+use auth::access::Token;
+use auth::claim::Claim;
 use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Form, Json, Router, extract::Query};
+use http::StatusCode;
 use serde::{Deserialize, Serialize};
-use auth::access::Token;
-use auth::claim::{Claim};
-use http::{StatusCode};
+
+#[cfg(feature = "openapi")]
+use utoipa::OpenApi;
+#[cfg(feature = "openapi")]
+use utoipa_axum::router::OpenApiRouter;
+#[cfg(feature = "openapi")]
+use utoipa_axum::routes;
+#[cfg(feature = "openapi")]
+use utoipa_swagger_ui::SwaggerUi;
+
 // 获取当前路由
 pub fn get_routes() -> Router<AppState> {
     let routes = Router::new()
@@ -27,11 +37,14 @@ pub fn get_routes() -> Router<AppState> {
     res_routes
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Deserialize, Serialize, Clone, Debug)]
 struct UpdateQuery {
     id: String,
     limit: Option<u32>,
 }
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Clone, Serialize, Deserialize)]
 struct User {
     id: u64,
@@ -39,57 +52,106 @@ struct User {
 }
 
 /** 登陆请求 */
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Clone, Serialize, Deserialize)]
-struct UserLogin{
+struct UserLogin {
     username: String,
     password: String,
     // code : String,
 }
 
 type TOKEN = String;
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Clone, Serialize, Deserialize)]
-struct UserLoginResponse{
-    token: TOKEN
+struct UserLoginResponse {
+    token: TOKEN,
 }
 
-async fn update_user_by_id(
+#[cfg_attr(feature="openapi",utoipa::path(
+    get,
+    path = "/update_user_by_id",
+    params(
+        ("id" = u64, Query, description = "用户 ID"),
+        ("name" = Option<String>, Query, description = "新用户名")
+    ),
+    responses((status= 200, description = "根据 ID 更新用户", body= String)),
+    tag = "User 管理"
+))]
+pub async fn update_user_by_id(
     Query(params): Query<UpdateQuery>,
 ) -> Result<impl IntoResponse, AppError> {
     let id = params.id;
     Ok(format!("update_user_by_id: {}", id).into_response())
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Deserialize, Serialize, Clone, Debug)]
 struct DeleteQuery {
     id: u64,
 }
 
-async fn delete_user_by_id(
+#[cfg_attr(feature="openapi",utoipa::path(
+    delete,
+    path = "/delete_user_by_id",
+    responses((status= 200, description = "根据ID删除用户", body= String)),
+    tag = "User 管理"
+))]
+pub async fn delete_user_by_id(
     Query(params): Query<DeleteQuery>,
 ) -> Result<impl IntoResponse, AppError> {
     let id = params.id;
     Ok(format!("update_user_by_id: {}", id).into_response())
 }
 
-async fn login_check_user(State(app_state): State<AppState>, Form(user): Form<User>) -> String {
+#[cfg_attr(feature="openapi",utoipa::path(
+    post,
+    request_body = User,
+    path = "/login_check",
+    responses((status= 200, description = "登陆校验", body= String)),
+    tag = "User 管理"
+))]
+pub async fn login_check_user(State(app_state): State<AppState>, Form(user): Form<User>) -> String {
     format!(
         "url: {}, 登录用户: {}, 密码: {}",
         app_state.config.database.url, user.id, user.name
     )
 }
 
-async fn add_user(Json(user): Json<User>) -> Json<User> {
+#[cfg_attr(feature="openapi",utoipa::path(
+    post,
+    request_body = User,
+    path = "/add_user",
+    responses((status= 200, description = "添加用户", body= User)),
+    tag = "User 管理"
+))]
+pub async fn add_user(Json(user): Json<User>) -> Json<User> {
     Json(user)
 }
 
-async fn get_user_by_id(Path(user_id): Path<u64>) -> Result<Json<User>, AppError> {
+#[cfg_attr(feature="openapi",utoipa::path(
+    get,
+    params (
+        ("user_id" = u64, Path, description = "用户ID")
+    ),
+    path = "/get_user_by_id",
+    responses((status= 200, description = "获取用户根据Id", body= User)),
+    tag = "User 管理"
+))]
+pub async fn get_user_by_id(Path(user_id): Path<u64>) -> Result<Json<User>, AppError> {
     Ok(Json(User {
         id: user_id,
         name: "xhy".to_string(),
     }))
 }
 
-async fn try_response_with_app_error() -> Result<String, AppError> {
+#[cfg_attr(feature="openapi",utoipa::path(
+    get,
+    path = "/try_err",
+    responses((status= 200, description = "错误示例", body= String)),
+    tag = "User 管理"
+))]
+pub async fn try_response_with_app_error() -> Result<String, AppError> {
     Err(AppError::InternalServerError(anyhow::Error::msg(
         "Internal server error",
     )))
@@ -100,7 +162,14 @@ async fn not_found() -> Result<impl IntoResponse, AppError> {
 }
 
 /** POST 登陆*/
-async fn login(Json(payload): Json<UserLogin>) -> crate::result::Result<Response> {
+#[cfg_attr(feature="openapi",utoipa::path(
+    post,
+    request_body = UserLogin,
+    path = "/login",
+    responses((status= 200, description = "登陆", body= String)),
+    tag = "User 管理"
+))]
+pub async fn login(Json(payload): Json<UserLogin>) -> crate::result::Result<Response> {
     // 检验用户名和密码
     payload.username;
     payload.password;
@@ -117,10 +186,25 @@ async fn login(Json(payload): Json<UserLogin>) -> crate::result::Result<Response
     // )
 
     //  生成 token 返回
-    Ok( Response::builder()
+    Ok(Response::builder()
         .status(http::StatusCode::OK)
         .body("Don't permission".into())
-        .unwrap()
-    )
+        .unwrap())
 }
 
+#[cfg(feature="openapi")]
+#[derive(OpenApi)]
+#[openapi(
+
+    paths(
+        update_user_by_id,
+        delete_user_by_id,
+        get_user_by_id,
+        add_user,
+        login_check_user,
+        login,
+        try_response_with_app_error
+    ),
+    tags ((name = "User 管理", description = "普通用户相关接口"),)
+)]
+pub struct UserApi;


### PR DESCRIPTION
We can use 'utopia-swagger-ui ' to auto-generate the 'openapi' doc. 
But it is mixd in the route file.
I will try to deseprate the doc and route, next!